### PR TITLE
Feature: Added new option 'composeEventName' to analyticsMiddleware.

### DIFF
--- a/src/analyticsMiddleware.js
+++ b/src/analyticsMiddleware.js
@@ -49,23 +49,25 @@ const composeEventPayload = ({
   reducerName,
   defaultMixins,
   mapStateToVariables,
+  composeEventName,
   }) => {
   const composeMixin = composeMixinVariables(reducerName, defaultMixins, mapStateToVariables)
-  return ({ variables, mixins, ...rest }, state) => ({
-    ...rest,
-    variables: {
-      ...composeMixin(mixins, state),
-      ...variables,
-    },
-  })
+  return ({ variables, mixins, eventName, ...rest }, state) => {
+    const composedVariables = { ...composeMixin(mixins, state), ...variables }
+    return {
+      ...rest,
+      eventName: eventName || composeEventName(composedVariables, state) || null,
+      variables: composedVariables,
+    }
+  }
 }
 
 export default ({
   pageViewMixins = [],
   eventMixins = [],
-  mapStateToVariables = () => ({}), /* (store: Redux.Store) => Object */
-  getLocationInStore =
-   () => null, /* (store: Redux.Store) => Object */
+  mapStateToVariables = () => ({}), /* (state: Object) => Object */
+  getLocationInStore = () => null, /* (state: Object) => Object */
+  composeEventName = () => null, /* (composedVariables: Object, state: Object) => string | null */
   reducerName = defaultReducerName,
 } = {}) => {
   const pageViewPayload = composePageViewPayload({ reducerName,
@@ -76,6 +78,7 @@ export default ({
   const eventPayload = composeEventPayload({ reducerName,
     defaultMixins: eventMixins,
     mapStateToVariables,
+    composeEventName,
   })
 
   return ({ dispatch, getState }) => (next) => (action) => {

--- a/test/analyticsMiddleware/event.test.js
+++ b/test/analyticsMiddleware/event.test.js
@@ -625,3 +625,94 @@ describe('with option eventMixins = array, mapStateToVariables, after pageView',
     })
   })
 })
+
+describe('with composeEventName', () => {
+  const createMiddleware = (options) => {
+    const analytics = analyticsMiddleware({
+      ...options,
+      composeEventName: (composedVariables, state) =>
+      `${composedVariables.prop15 || '0'}:${composedVariables.prop10 || '0'}:${composedVariables.events[0]}`,
+    })
+    const store = createStore(combineReducers({
+      [reducerName]: reducer,
+      article: (state) => ({ ...state }),
+      routing: (state) => ({ ...state }),
+    }), mockState1, applyMiddleware(analytics))
+    const testApply = analytics(store)((action) => action)
+    return { store, testApply, analytics }
+  }
+  it('without other options, no payload mixins, after pageView', () => {
+    const { testApply, store } = createMiddleware({})
+    store.dispatch(sendPageView(pageViewVariables))
+    const action = sendEvent(eventVariables)
+    const action2 = testApply(action)
+    const expectedVars = withEventPayloadAfterPageView['[],[],*']
+    expect(action2).to.deep.equal({
+      type: SEND_EVENT,
+      payload: {
+        variables: expectedVars,
+        eventName: `0:0:${expectedVars.events[0]}`,
+      },
+    })
+  })
+
+  it('with mapStateToVariables, payload mixins = array, before pageView', () => {
+    const { testApply } = createMiddleware({ mapStateToVariables })
+    const action = sendEvent(eventVariables, eventPayloadMixins)
+    const action2 = testApply(action)
+    const expectedVars = withEventPayload['[],eventPayloadMixins,mapStateToVariables']
+    expect(action2).to.deep.equal({
+      type: SEND_EVENT,
+      payload: {
+        variables: expectedVars,
+        eventName: `0:${expectedVars.prop10}:${expectedVars.events[0]}`,
+      },
+    })
+  })
+
+  it('with eventMixins, no payload mixins, after pageView', () => {
+    const { testApply, store } = createMiddleware({ eventMixins })
+    store.dispatch(sendPageView(pageViewVariables))
+    const action = sendEvent(eventVariables)
+    const action2 = testApply(action)
+    const expectedVars = withEventPayloadAfterPageView['eventMixins,[],']
+    expect(action2).to.deep.equal({
+      type: SEND_EVENT,
+      payload: {
+        variables: expectedVars,
+        eventName: `${expectedVars.prop15}:0:${expectedVars.events[0]}`,
+      },
+    })
+  })
+
+  it('with eventMixins and mapStateToVariables, payload mixins = true, after pageView', () => {
+    const { testApply, store } = createMiddleware({ mapStateToVariables, eventMixins })
+    store.dispatch(sendPageView(pageViewVariables))
+    const action = sendEvent(eventVariables, true)
+    const action2 = testApply(action)
+    const expectedVars = withEventPayloadAfterPageView['*,true,mapStateToVariables']
+    expect(action2).to.deep.equal({
+      type: SEND_EVENT,
+      payload: {
+        variables: expectedVars,
+        eventName: `${expectedVars.prop15}:${expectedVars.prop10}:${expectedVars.events[0]}`,
+      },
+    })
+  })
+
+  it('with eventMixins and mapStateToVariables, mixins = [], eventName="top:event1"', () => {
+    const { testApply, store } = createMiddleware({ mapStateToVariables, eventMixins })
+    store.dispatch(sendPageView(pageViewVariables))
+    const action = sendEvent(eventVariables, [], 'top:event1')
+    const action2 = testApply(action)
+    const expectedVars = withEventPayloadAfterPageView['eventMixins,[],mapStateToVariables']
+    expect(action2).to.deep.equal({
+      type: SEND_EVENT,
+      payload: {
+        variables: expectedVars,
+        eventName: 'top:event1',
+      },
+    })
+  })
+})
+

--- a/test/analyticsMiddleware/functions.test.js
+++ b/test/analyticsMiddleware/functions.test.js
@@ -411,6 +411,7 @@ describe('composeEventPayload', () => {
         reducerName,
         defaultMixins: [],
         mapStateToVariables: () => ({}),
+        composeEventName: () => null,
       })
     })
     it('only variables', () => {
@@ -419,6 +420,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['[],[],*'],
+        eventName: null,
       })
     })
     it('with mixins = array', () => {
@@ -428,6 +430,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['[],eventPayloadMixins,'],
+        eventName: null,
       })
     })
     it('with mixins = true', () => {
@@ -437,6 +440,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['*,true,'],
+        eventName: null,
       })
     })
     it('with mixins = false', () => {
@@ -446,6 +450,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: eventVariables,
+        eventName: null,
       })
     })
   })
@@ -456,6 +461,7 @@ describe('composeEventPayload', () => {
         reducerName,
         defaultMixins: eventMixins,
         mapStateToVariables: () => ({}),
+        composeEventName: () => null,
       })
     })
     it('with mixins = []', () => {
@@ -465,6 +471,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['eventMixins,[],'],
+        eventName: null,
       })
     })
     it('with mixins = array', () => {
@@ -474,6 +481,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['eventMixins,eventPayloadMixins,'],
+        eventName: null,
       })
     })
     it('with mixins = true', () => {
@@ -483,6 +491,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['*,true,'],
+        eventName: null,
       })
     })
     it('with mixins = false', () => {
@@ -492,6 +501,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['*,false,*'],
+        eventName: null,
       })
     })
   })
@@ -502,6 +512,7 @@ describe('composeEventPayload', () => {
         reducerName,
         defaultMixins: eventMixins,
         mapStateToVariables,
+        composeEventName: () => null,
       })
     })
     it('with mixins = []', () => {
@@ -511,6 +522,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['eventMixins,[],mapStateToVariables'],
+        eventName: null,
       })
     })
     it('with mixins = array', () => {
@@ -520,6 +532,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['eventMixins,eventPayloadMixins,mapStateToVariables'],
+        eventName: null,
       })
     })
     it('with mixins = true', () => {
@@ -529,6 +542,7 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['*,true,mapStateToVariables'],
+        eventName: null,
       })
     })
     it('with mixins = false', () => {
@@ -538,6 +552,65 @@ describe('composeEventPayload', () => {
       }, mockState1)
       expect(payload).deep.equal({
         variables: withEventPayload['*,false,*'],
+        eventName: null,
+      })
+    })
+  })
+
+  describe('with composeEventName', () => {
+    let composePayload
+    beforeEach(() => {
+      composePayload = composeEventPayload({
+        reducerName,
+        defaultMixins: eventMixins,
+        mapStateToVariables,
+        composeEventName: (composedVariables, state) =>
+        `${state.article.title}:${composedVariables.prop30 || '0'}:`
+        + `${composedVariables.prop40 || composedVariables.prop31 || '0'}:${composedVariables.events[0]}`,
+      })
+    })
+    it('with mixins = []', () => {
+      const payload = composePayload({
+        variables: eventVariables,
+        mixins: [],
+      }, mockState1)
+      const expectedVars = withEventPayload['eventMixins,[],mapStateToVariables']
+      expect(payload).deep.equal({
+        variables: expectedVars,
+        eventName: `${mockState1.article.title}:0:${expectedVars.prop31}:${expectedVars.events[0]}`,
+      })
+    })
+    it('with mixins = array', () => {
+      const payload = composePayload({
+        variables: eventVariables,
+        mixins: eventPayloadMixins,
+      }, mockState1)
+      const expectedVars = withEventPayload['eventMixins,eventPayloadMixins,mapStateToVariables']
+      expect(payload).deep.equal({
+        variables: expectedVars,
+        eventName: `${mockState1.article.title}:0:${expectedVars.prop31}:${expectedVars.events[0]}`,
+      })
+    })
+    it('with mixins = true', () => {
+      const payload = composePayload({
+        variables: eventVariables,
+        mixins: true,
+      }, mockState1)
+      const expectedVars = withEventPayload['*,true,mapStateToVariables']
+      expect(payload).deep.equal({
+        variables: expectedVars,
+        eventName: `${mockState1.article.title}:${expectedVars.prop30}:${expectedVars.prop40}:${expectedVars.events[0]}`,
+      })
+    })
+    it('with mixins = false', () => {
+      const payload = composePayload({
+        variables: eventVariables,
+        mixins: false,
+      }, mockState1)
+      const expectedVars = withEventPayload['*,false,*']
+      expect(payload).deep.equal({
+        variables: expectedVars,
+        eventName: `${mockState1.article.title}:0:0:${expectedVars.events[0]}`,
       })
     })
   })


### PR DESCRIPTION
By passing a function to this option, eventName is automatically added by the middleware when not specified in original payload.
The function takes composed variables (which is outputted by middleware) as 1st argument and reducer state as 2nd argument,
and must return eventName in the form of a string value.