### PR TITLE
SendAnalytics HoCでPageView送信時にpropのスナップショットを取る機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-analytics",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1065,9 +1065,9 @@
       "dev": true
     },
     "chai": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.0.tgz",
-      "integrity": "sha1-MxoDkbVcOvh0CunDt0WLwcOAXm0=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
+      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
       "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
@@ -1769,7 +1769,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -3301,7 +3301,6 @@
     "invariant": {
       "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
       }
@@ -3702,8 +3701,7 @@
     "lodash-es": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
-      "dev": true
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -4717,7 +4715,8 @@
       }
     },
     "reduce-reducers": {
-      "version": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
       "integrity": "sha1-+htHGLxSkqcd3R5dg5yb6pdw8Us="
     },
     "redux": {
@@ -4733,10 +4732,14 @@
       }
     },
     "redux-actions": {
-      "version": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.10.1.tgz",
-      "integrity": "sha1-u0Qu433ZZDqUkz5AceCJ9DVYcTU=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-2.2.1.tgz",
+      "integrity": "sha1-1kGGslZJoTwFR4VH1811N7iSQQ0=",
       "requires": {
-        "reduce-reducers": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz"
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "reduce-reducers": "0.1.2"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-analytics",
-  "version": "0.1.4-rc1",
+  "version": "0.1.4",
   "description": "Analytics middleware for React+Redux",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "hoist-non-react-statics": "^1.2.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "redux-actions": "^0.10.1"
+    "redux-actions": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -46,7 +46,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-react": "^6.24.1",
-    "chai": "^4.1.0",
+    "chai": "^4.1.1",
     "enzyme": "^2.9.1",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-analytics",
-  "version": "0.1.3",
+  "version": "0.1.4-rc1",
   "description": "Analytics middleware for React+Redux",
   "main": "lib/index.js",
   "directories": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -10,6 +10,7 @@ export const GLOBAL_VARIABLES_UPDATE = ANALYTICS + '/global/variables/update'
 
 export const PAGE_VARIABLES_CLEAR = ANALYTICS + '/page/variables/clear'
 export const PAGE_VARIABLES_UPDATE = ANALYTICS + '/page/variables/update'
+export const PAGE_SNAPSHOT_PROPS = ANALYTICS + '/page/snapshot-props'
 
 export const LOCATION_PUSH = ANALYTICS + '/location/push'
 export const LOCATION_POP = ANALYTICS + '/location/pop'
@@ -38,3 +39,5 @@ export const updateGlobalVariables = createAction(GLOBAL_VARIABLES_UPDATE, (vari
 export const clearPageVariables = createAction(PAGE_VARIABLES_CLEAR, () => ({}))
 export const updatePageVariables = createAction(PAGE_VARIABLES_UPDATE, (variables) => ({ variables }))
 export const fallbackPageView = createAction(FALLBACK_PAGEVIEW, (location) => ({ location }))
+
+export const snapshotPageProps = createAction(PAGE_SNAPSHOT_PROPS, (props) => ({ props }))

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,9 @@ import { pick } from 'lodash/fp'
 import debugFactory from 'debug'
 import { LOCATION_PUSH, LOCATION_POP, LOCATION_REPLACE,
   GLOBAL_VARIABLES_CLEAR, GLOBAL_VARIABLES_UPDATE,
-  PAGE_VARIABLES_CLEAR, PAGE_VARIABLES_UPDATE, SEND_PAGE_VIEW } from './actions'
+  PAGE_VARIABLES_CLEAR, PAGE_VARIABLES_UPDATE, SEND_PAGE_VIEW,
+  PAGE_SNAPSHOT_PROPS,
+ } from './actions'
 
 const debug = debugFactory('analytics')
 
@@ -33,6 +35,7 @@ const INITIAL_STATE = {
     location: null,
     variables: {},
     lastPageViewSent: null,
+    snapshot: null,
   },
   prevPages: [],
   initialState: true,
@@ -78,6 +81,13 @@ export default handleActions({
       },
     },
   }),
+  [PAGE_SNAPSHOT_PROPS]: (state, { payload: { props } }) => ({
+    ...state,
+    page: {
+      ...state.page,
+      snapshot: props,
+    },
+  }),
   [LOCATION_PUSH]: (state, { payload: { location, variables = {}, inherits = false } }) => {
     const prevPages = state.initialState ? [] : [state.page, ...state.prevPages].slice(0, MAX_LOCATION_STACK)
     const inherited = inheritVariables(variables, state.page, inherits)
@@ -88,6 +98,7 @@ export default handleActions({
         variables: inherited,
         location,
         lastPageViewSent: null,
+        snapshot: null,
       },
       initialState: false,
     }
@@ -100,6 +111,7 @@ export default handleActions({
         variables: inherited,
         location,
         lastPageViewSent: null,
+        snapshot: null,
       },
       initialState: false,
     }

--- a/src/sendAnalytics.js
+++ b/src/sendAnalytics.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { isFunction, pickBy } from 'lodash/fp'
 import hoistStatics from 'hoist-non-react-statics'
 import { getDisplayName, valueOrFunction } from './utils'
-import { sendPageView } from './actions'
+import { sendPageView, snapshotPageProps } from './actions'
 import { sendAnalyticsPropertyName } from './names'
 
 const composeVariables = (staticVariables, mapPropsToVariables) => (props, state) => {
@@ -20,6 +20,7 @@ export default ({
   sendPageViewOnDidUpdate = false, /* boolean | ( prevProps: Object, props: Object, state: Object) => boolean */
   mapPropsToVariables, /* (props: Object, state: Object) => Object */
   onDataReady = true, /* boolean | (props: Object, state: Object) => boolean */
+  snapshotPropsOnPageView = false, /* boolean | (props: Object, state: Object) => boolean */
   mixins = [],
   ...staticVariables
 }) => (WrappedComponent) => {
@@ -27,6 +28,7 @@ export default ({
   const shouldSendOnDidMount = valueOrFunction(sendPageViewOnDidMount)
   const shouldSendOnDidUpdate = valueOrFunction(sendPageViewOnDidUpdate)
   const canSendPageView = valueOrFunction(onDataReady)
+  const shouldsnapshotProps = valueOrFunction(snapshotPropsOnPageView)
 
   class WrapperComponent extends Component {
 
@@ -52,6 +54,9 @@ export default ({
         this.isPageViewScheduled = false
         this.preventDuplicate = true
         const variables = composeVars(nextProps, state)
+        if (shouldsnapshotProps(nextProps, state)) {
+          dispatch(snapshotPageProps(nextProps))
+        }
         dispatch(sendPageView(variables, mixins))
       }
     }
@@ -70,6 +75,9 @@ export default ({
           return
         }
         const variables = composeVars(props, state)
+        if (shouldsnapshotProps(props, state)) {
+          dispatch(snapshotPageProps(props))
+        }
         dispatch(sendPageView(variables, mixins))
       } else {
         this.isPageViewScheduled = true

--- a/test/_data/state.js
+++ b/test/_data/state.js
@@ -1,5 +1,6 @@
 import { reducerName } from '../../src/names'
 import { news, newsLatest } from '../_data/location'
+import { newsPageProps } from './props'
 
 export const mockState1 = {
   article: {
@@ -32,6 +33,7 @@ export const mockState1 = {
         prop41: 'prop41 from topPageProps',
       },
       lastPageViewSent: null,
+      snapshot: { ...newsPageProps },
     },
     prevPages: [],
     initialState: false,
@@ -46,6 +48,7 @@ export const mockState2 = {
     page: {
       ...mockState1[reducerName].page,
       location: newsLatest,
+      snapshot: null,
     },
   },
 }

--- a/test/actions/snapshot.test.js
+++ b/test/actions/snapshot.test.js
@@ -1,0 +1,21 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { snapshotPageProps, PAGE_SNAPSHOT_PROPS,
+ } from '../../src/actions'
+
+describe('snapshotPageProps', () => {
+  it('default', () => {
+    const props = {
+      data11: 'data11 from newsPageProps',
+      data12: 'data12 from newsPageProps',
+      data21: 'data21 from newsPageProps',
+    }
+    const action = snapshotPageProps(props)
+    expect(action).to.deep.equal({
+      type: PAGE_SNAPSHOT_PROPS,
+      payload: {
+        props: { ...props },
+      },
+    })
+  })
+})

--- a/test/createLocationSubscriber.test.js
+++ b/test/createLocationSubscriber.test.js
@@ -14,6 +14,7 @@ const initialState = {
     location: null,
     variables: {},
     lastPageViewSent: null,
+    snapshot: null,
   },
   prevPages: [],
   initialState: true,
@@ -40,6 +41,7 @@ describe('createLocationSubscriber', () => {
     // confirm no side effect
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
   })
@@ -54,6 +56,7 @@ describe('createLocationSubscriber', () => {
     // confirm no side effect
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
   })
@@ -68,6 +71,7 @@ describe('createLocationSubscriber', () => {
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
   })
@@ -82,12 +86,14 @@ describe('createLocationSubscriber', () => {
       location: news,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.initialState).to.deep.equal(false)
     expect(state2.prevPages).to.deep.equal([{
       location: top,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     }])
     // confirm no side effect
     expect(state2.global).to.deep.equal(state.global)
@@ -104,6 +110,7 @@ describe('createLocationSubscriber', () => {
       location: newsLatest,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.initialState).to.deep.equal(false)
     expect(state2.prevPages).to.deep.equal([
@@ -111,11 +118,13 @@ describe('createLocationSubscriber', () => {
         location: news,
         variables: {},
         lastPageViewSent: null,
+        snapshot: null,
       },
       {
         location: top,
         variables: {},
         lastPageViewSent: null,
+        snapshot: null,
       }])
     // confirm no side effect
     expect(state2.global).to.deep.equal(state.global)
@@ -132,6 +141,7 @@ describe('createLocationSubscriber', () => {
       location: top,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.prevPages).to.deep.equal([])
     expect(state2.initialState).to.deep.equal(false)
@@ -149,6 +159,7 @@ describe('createLocationSubscriber', () => {
       location: news,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.initialState).to.deep.equal(false)
     expect(state2.prevPages).to.deep.equal([])
@@ -166,12 +177,14 @@ describe('createLocationSubscriber', () => {
       location: news,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.initialState).to.deep.equal(false)
     expect(state2.prevPages).to.deep.equal([{
       location: top,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     }])
     // confirm no side effect
     expect(state2.global).to.deep.equal(state.global)
@@ -187,6 +200,7 @@ describe('createLocationSubscriber', () => {
       location: top,
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.initialState).to.deep.equal(false)
     expect(state2.prevPages).to.deep.equal([])

--- a/test/reducer/location.test.js
+++ b/test/reducer/location.test.js
@@ -11,6 +11,7 @@ const initialState = {
     location: null,
     variables: {},
     lastPageViewSent: null,
+    snapshot: null,
   },
   prevPages: [],
   initialState: true,
@@ -33,6 +34,7 @@ const secondState = {
       prop15: 'prop15 from topPageProps',
     },
     lastPageViewSent: null,
+    snapshot: null,
   },
   prevPages: [],
   initialState: false,
@@ -56,6 +58,7 @@ const thirdState = {
       prop12: 'prop12 from newsPageProps',
     },
     lastPageViewSent: null,
+    snapshot: null,
   },
   prevPages: [{
     location: {
@@ -69,6 +72,7 @@ const thirdState = {
       prop15: 'prop15 from topPageProps',
     },
     lastPageViewSent: null,
+    snapshot: null,
   }],
   initialState: false,
 }
@@ -90,6 +94,7 @@ describe('pushLocation', () => {
       },
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     // confirm no side-effect
     expect(state2.initialState).to.deep.equal(false)
@@ -137,6 +142,7 @@ describe('pushLocation', () => {
         prop15: 'prop15 from topPageProps',
       },
       lastPageViewSent: null,
+      snapshot: null,
     })
   })
 
@@ -193,6 +199,7 @@ describe('pushLocation', () => {
         prop12: 'prop12 from newsPageProps',
       },
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state3.prevPages[0]).to.deep.equal(state2.page)
     expect(state3.prevPages[1]).to.deep.equal(state1.page)
@@ -217,6 +224,7 @@ describe('replaceLocation', () => {
       },
       variables: {},
       lastPageViewSent: null,
+      snapshot: null,
     })
     // confirm no side-effect
     expect(state2.initialState).to.deep.equal(false)
@@ -274,6 +282,7 @@ describe('replaceLocation', () => {
         prop12: 'prop12 from newsPageProps',
       },
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state2.prevPages).to.deep.equal(state.prevPages)
   })
@@ -319,6 +328,7 @@ describe('replaceLocation', () => {
         prop12: 'prop12 from newsLatestPageProps',
       },
       lastPageViewSent: null,
+      snapshot: null,
     })
     expect(state3.prevPages).to.deep.equal([])
   })

--- a/test/reducer/send.test.js
+++ b/test/reducer/send.test.js
@@ -2,6 +2,7 @@ import { describe, it } from 'mocha'
 import { expect } from 'chai'
 import { sendPageView, sendEvent, fallbackPageView, SEND_PAGE_VIEW } from '../../src/actions'
 import reducer from '../../src/reducer'
+import { topPageProps } from '../_data/props'
 
 const initialState = {
   global: {
@@ -24,6 +25,7 @@ const initialState = {
       prop15: 'prop15 from topPageProps',
     },
     lastPageViewSent: null,
+    snapshot: { ...topPageProps },
   },
   prevPages: [],
   initialState: false,
@@ -46,6 +48,7 @@ describe('sendPageView', () => {
     })
     // confirm no side effect
     expect(state2.page.variables).to.deep.equal(state.page.variables)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
@@ -62,6 +65,7 @@ describe('sendPageView', () => {
     })
     // confirm no side effect
     expect(state2.page.variables).to.deep.equal(state.page.variables)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
@@ -87,6 +91,7 @@ describe('sendPageView', () => {
     // confirm no side effect
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -140,6 +145,7 @@ describe('sendPageView', () => {
     })
     expect(state2.page.location).to.deep.equal(locNews)
     // confirm no side effect
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -159,6 +165,7 @@ describe('sendEvent', () => {
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -176,6 +183,7 @@ describe('sendEvent', () => {
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -193,6 +201,7 @@ describe('sendEvent', () => {
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -210,6 +219,7 @@ describe('sendEvent', () => {
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -229,6 +239,7 @@ describe('fallbackPageView', () => {
     expect(state2.page.variables).to.deep.equal(state.page.variables)
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)

--- a/test/reducer/snapshot.test.js
+++ b/test/reducer/snapshot.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { snapshotPageProps, replaceLocation, pushLocation, popLocation } from '../../src/actions'
+import reducer from '../../src/reducer'
+import { reducerName } from '../../src/names'
+import { mockState1 } from '../_data/state'
+import { topPageProps, newsPageProps } from '../_data/props'
+import { top, news } from '../_data/location'
+
+describe('updateGlobalVariables', () => {
+  it('default', () => {
+    const state = { ...mockState1[reducerName] }
+    const state2 = reducer(state, snapshotPageProps(topPageProps))
+    expect(state2.page.snapshot).to.deep.equal({ ...topPageProps })
+
+    // confirm no side-effect
+    expect(state2.page.variables).to.deep.equal(state.page.variables)
+    expect(state2.page.location).to.deep.equal(state.page.location)
+    expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.initialState).to.deep.equal(state.initialState)
+    expect(state2.prevPages).to.deep.equal(state.prevPages)
+    expect(state2.global).to.deep.equal(state.global)
+  })
+
+  it('confirm snapshot is cleared after replaceLocation', () => {
+    const state = { ...mockState1[reducerName] }
+    const state2 = reducer(state, replaceLocation(top))
+    const state3 = reducer(state2, snapshotPageProps(topPageProps))
+    expect(state3.page.snapshot).to.deep.equal({ ...topPageProps })
+    const state4 = reducer(state3, replaceLocation(news))
+    expect(state4.page.snapshot).to.equal(null)
+    const state5 = reducer(state4, snapshotPageProps(newsPageProps))
+    expect(state5.page.snapshot).to.deep.equal({ ...newsPageProps })
+  })
+
+  it('confirm snapshot is restored after push & pop', () => {
+    const state = { ...mockState1[reducerName] }
+    const state2 = reducer(state, replaceLocation(top))
+    const state3 = reducer(state2, snapshotPageProps(topPageProps))
+    expect(state3.page.snapshot).to.deep.equal({ ...topPageProps })
+    const state4 = reducer(state3, pushLocation(news))
+    expect(state4.page.snapshot).to.equal(null)
+    const state5 = reducer(state4, snapshotPageProps(newsPageProps))
+    expect(state5.page.snapshot).to.deep.equal({ ...newsPageProps })
+    const state6 = reducer(state5, popLocation())
+    expect(state6.page.snapshot).to.deep.equal({ ...topPageProps })
+  })
+})

--- a/test/reducer/variables.test.js
+++ b/test/reducer/variables.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 import { clearGlobalVariables, updateGlobalVariables,
   clearPageVariables, updatePageVariables } from '../../src/actions'
 import reducer from '../../src/reducer'
+import { topPageProps } from '../_data/props'
 
 const initialState = {
   global: {
@@ -25,6 +26,7 @@ const initialState = {
       prop15: 'prop15 from topPageProps',
     },
     lastPageViewSent: null,
+    snapshot: { ...topPageProps },
   },
   prevPages: [],
   initialState: false,
@@ -52,6 +54,7 @@ describe('updatePageVariables', () => {
     // confirm no side-effect
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)
@@ -69,6 +72,7 @@ describe('clearPageVariables', () => {
     // confirm no side-effect
     expect(state2.page.location).to.deep.equal(state.page.location)
     expect(state2.page.lastPageViewSent).to.deep.equal(state.page.lastPageViewSent)
+    expect(state2.page.snapshot).to.deep.equal(state.page.snapshot)
     expect(state2.initialState).to.deep.equal(state.initialState)
     expect(state2.prevPages).to.deep.equal(state.prevPages)
     expect(state2.global).to.deep.equal(state.global)

--- a/test/sendAnalytics/snapshot.test.js
+++ b/test/sendAnalytics/snapshot.test.js
@@ -1,0 +1,357 @@
+import 'jsdom-global/register'
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import React from 'react'
+import { createStore } from 'redux'
+import { mount } from 'enzyme'
+import { SEND_PAGE_VIEW, PAGE_SNAPSHOT_PROPS } from '../../src/actions'
+import sendAnalytics from '../../src/sendAnalytics'
+import { topPageProps } from '../_data/props'
+import { staticVariables } from '../_data/variables'
+import { mapPropsToVariables2 } from '../_data/mapFunction'
+import MockComponent from '../_data/component'
+import { withStaticVariables } from '../_data/hocOutput'
+import { pageViewPayloadMixins } from '../_data/mixins'
+
+/* eslint-disable callback-return */
+const expectAction = (variables, mixins = []) => (action) => {
+  expect(action).to.deep.equal({
+    type: SEND_PAGE_VIEW,
+    payload: {
+      location: null,
+      variables,
+      mixins,
+    },
+  })
+}
+
+const mountComponent = ({ options, initialState, reducer, onDispatched, initialProps }) => {
+  let store
+  let Component
+  let wrapper
+  const promise = new Promise((resolve, reject) => {
+    store = createStore(reducer, initialState)
+    Component = sendAnalytics(options)(MockComponent)
+    wrapper = mount((<Component {...initialProps} />), {
+      context: { store: { ...store, dispatch: onDispatched(resolve, reject) } },
+    })
+  })
+  return { store, Component, wrapper, promise }
+}
+
+const resolveAfter = (ms) => new Promise((resolve, reject) => {
+  setTimeout(() => { resolve() }, ms)
+})
+
+describe('sendPageViewOnDidMount=true, sendPageViewOnDidUpdate=false', () => {
+  let count
+  let options
+  let reducer
+  let initialState
+  let initialProps
+  let onDispatched
+
+  beforeEach(() => {
+    count = 0
+    options = {}
+    reducer = (state) => ({ ...state })
+    initialState = {}
+    initialProps = {}
+  })
+
+  it('onDataReady=true, snapshotPropsOnPageView=true', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: false,
+      onDataReady: true,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: true,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: topPageProps,
+          },
+        })
+      } else if (count === 1) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    expect(count).to.equal(2)
+    return promise
+  })
+
+  it('onDataReady=(props)=>props.ready, snapshotPropsOnPageView=true', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: false,
+      onDataReady: (props) => props.ready,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: true,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: { ...topPageProps,
+              ready: true,
+              click: 1,
+            },
+          },
+        })
+      } else if (count === 1) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    // confirm sendPageView is not dispatched yet
+    expect(count).to.equal(0)
+    wrapper.setProps({ click: 1 })
+    expect(count).to.equal(0)
+    wrapper.setProps({ ready: true })
+    expect(count).to.equal(2)
+    return promise
+  })
+
+  it('onDataReady=(props,state)=>state.loaded, snapshotPropsOnPageView=true', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: false,
+      onDataReady: (props, state) => state.loaded,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: true,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: {
+              ...topPageProps,
+              click: 2,
+            },
+          },
+        })
+      } else if (count === 1) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { store, wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    // confirm sendPageView is not dispatched yet
+    wrapper.setProps({ click: 1 })
+    store.dispatch({ type: '', payload: { loaded: true } })
+    expect(count).to.equal(0)
+    wrapper.setProps({ click: 2 })
+    expect(count).to.equal(2)
+    return promise
+  })
+
+  it('onDataReady=(props)=>props.ready, snapshotPropsOnPageView=(props,state)=>state.loaded', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: false,
+      onDataReady: (props) => props.ready,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: true,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: { ...topPageProps,
+              ready: true,
+              click: 2,
+            },
+          },
+        })
+      } else if (count === 1) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { store, wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    // confirm sendPageView is not dispatched yet
+    wrapper.setProps({ click: 1 })
+    store.dispatch({ type: '', payload: { loaded: true } })
+    wrapper.setProps({ click: 2 })
+    expect(count).to.equal(0)
+    wrapper.setProps({ ready: true })
+    expect(count).to.equal(2)
+    return promise
+  })
+
+  it('onDataReady=(props,state)=>state.loaded, snapshotPropsOnPageView=(props,state)=>props.ready', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: false,
+      onDataReady: (props, state) => state.loaded,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: (props) => props.ready,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expectAction(withStaticVariables.mapPropsToVariables2[','], pageViewPayloadMixins)(action)
+      } else {
+        reject()
+      }
+      count++
+    }
+    const { store, wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    // confirm sendPageView is not dispatched yet
+    wrapper.setProps({ click: 1 })
+    store.dispatch({ type: '', payload: { loaded: true } })
+    expect(count).to.equal(0)
+    wrapper.setProps({ click: 2 })
+    expect(count).to.equal(1)
+    wrapper.setProps({ ready: true })
+    expect(count).to.equal(1)
+    return Promise.race([promise, resolveAfter(300)])
+  })
+})
+
+describe('sendPageViewOnDidMount=true, sendPageViewOnDidUpdate=(prevProps, props) => !prevProps.ready && props.ready', () => {
+  let count
+  let options
+  let reducer
+  let initialState
+  let initialProps
+  let onDispatched
+
+  beforeEach(() => {
+    count = 0
+    options = {}
+    reducer = (state) => ({ ...state })
+    initialState = {}
+    initialProps = {}
+  })
+
+  it('onDataReady=true, snapshotPropsOnPageView=true', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: (prevProps, props) => !prevProps.ready && props.ready,
+      onDataReady: true,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: true,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: {
+              ...topPageProps,
+            },
+          },
+        })
+      } else if (count === 1) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+      } else if (count === 2) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: {
+              ...topPageProps,
+              ready: true,
+            },
+          },
+        })
+      } else if (count === 3) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    expect(count).to.equal(2)
+    wrapper.setProps({ ready: false })
+    expect(count).to.equal(2)
+    wrapper.setProps({ ready: true })
+    expect(count).to.equal(4)
+    return promise
+  })
+
+  it('onDataReady=true, snapshotPropsOnPageView=state.loaded', () => {
+    options = {
+      sendPageViewOnDidMount: true,
+      sendPageViewOnDidUpdate: (prevProps, props) => !prevProps.ready && props.ready,
+      onDataReady: true,
+      mapPropsToVariables: mapPropsToVariables2,
+      mixins: pageViewPayloadMixins,
+      snapshotPropsOnPageView: (props, state) => state.loaded,
+      ...staticVariables,
+    }
+    initialState = { loaded: false }
+    initialProps = { ...topPageProps }
+    reducer = (state, action) => ({ ...state, ...action.payload })
+    onDispatched = (resolve, reject) => (action) => {
+      if (count === 0) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+      } else if (count === 1) {
+        expect(action).to.deep.equal({
+          type: PAGE_SNAPSHOT_PROPS,
+          payload: {
+            props: {
+              ...topPageProps,
+              ready: true,
+            },
+          },
+        })
+      } else if (count === 2) {
+        expectAction(withStaticVariables.mapPropsToVariables2['props,'], pageViewPayloadMixins)(action)
+        resolve()
+      }
+      count++
+    }
+    const { store, wrapper, promise } = mountComponent({ options, reducer, initialState, initialProps, onDispatched })
+    expect(count).to.equal(1)
+    wrapper.setProps({ ready: false })
+    store.dispatch({ type: '', payload: { loaded: true } })
+    expect(count).to.equal(1)
+    wrapper.setProps({ ready: true })
+    expect(count).to.equal(3)
+    return promise
+  })
+})
+


### PR DESCRIPTION
フォーム画面等の保存時にカスタムイベントを送信するユースケースにおいて、フォームの変更前と変更後(保存時)の差分を考慮して送信するカスタムイベントのパラメータを変えたい、という要望に対応するための機能追加。