### PR TITLE
Add a feature to selectively suppress PageView in the middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ analyticsMiddleware(options : {
   mapStateToVariables?: (state: Object) => Object;
   getLocationInStore?: (state: Object) => Object;
   composeEventName?: (composedVariables: Object, state: Object) => string | null;
+  suppressPageView?: (state: Object, transformedAciton: Object) => boolean,
 }) : (store: Redux.Store) => (next: function) => (action: Object) => void
 ```
 ##### arguments
@@ -219,6 +220,10 @@ analyticsMiddleware(options : {
 * `[composeEventName]` ((composedVariables: Object, state: Object) => string | null)
   If a function is specified, the middleware use the return value of the function to override `eventName` property of `SEND_EVENT` payload. The function takes two arguments: `copmosedVariables` (1st argument) that are resulting `variables` composed of original payload `variables` and injected values, and `state` (2nd argument) that are the state of entire redux store. Like `getLocationInStore`, the middleware overrides property only if original property is `null` and the output value is **NOT** `null`.
   Default value: `() => null`
+
+* `[suppressPageView]` ((state: Object, transformedAction: Object) => boolean)
+  If a function is specified, `analyticsMiddleware` evaluates it just before passing a transfromed `SEND_PAGE_VIEW` action to the next middleware. If the return value is false, the action is discarded in this middleare and thus not be received by the plugin middlware (if it is properly placed **after** this one). This option is only useful if you cannot control dispatches of `SEND_PAGE_VIEW` by the lifecycle hooks of `sendAnalytics`.
+  Default value: `() => false`
 
 ##### Example
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-analytics",
-  "version": "0.1.5",
+  "version": "0.1.6-rc2",
   "description": "Analytics middleware for React+Redux",
   "main": "lib/index.js",
   "directories": {
@@ -24,7 +24,11 @@
     "test:build": "babel test --out-dir _test",
     "test:watch": "npm run test:build -- --watch",
     "preversion": "npm run test",
-    "version": "npm-run-all clean build"
+    "version": "npm-run-all clean build",
+    "release": "run-s version publish:public",
+    "release:beta": "run-s version publish:beta",
+    "publish:public": "npm publish",
+    "publish:beta": " npm publish --tag beta"
   },
   "author": "Recruit Technologies Co.,Ltd.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-analytics",
-  "version": "0.1.6-rc2",
+  "version": "0.1.6",
   "description": "Analytics middleware for React+Redux",
   "main": "lib/index.js",
   "directories": {

--- a/src/analyticsMiddleware.js
+++ b/src/analyticsMiddleware.js
@@ -68,6 +68,7 @@ export default ({
   mapStateToVariables = () => ({}), /* (state: Object) => Object */
   getLocationInStore = () => null, /* (state: Object) => Object */
   composeEventName = () => null, /* (composedVariables: Object, state: Object) => string | null */
+  suppressPageView = () => false, /* (state: Object, action: Object) => boolean */
   reducerName = defaultReducerName,
 } = {}) => {
   const pageViewPayload = composePageViewPayload({ reducerName,
@@ -83,9 +84,13 @@ export default ({
 
   return ({ dispatch, getState }) => (next) => (action) => {
     if (action.type === SEND_PAGE_VIEW) {
-      return next({ ...action, payload: pageViewPayload(action.payload, getState()) })
+      const state = getState()
+      const transformed = { ...action, payload: pageViewPayload(action.payload, state) }
+      if (suppressPageView(state, transformed)) {
+        return null
+      }
+      return next(transformed)
     }
-
     if (action.type === SEND_EVENT) {
       return next({ ...action, payload: eventPayload(action.payload, getState()) })
     }

--- a/test/analyticsMiddleware/pageview2.test.js
+++ b/test/analyticsMiddleware/pageview2.test.js
@@ -1,0 +1,103 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { createStore, combineReducers, applyMiddleware } from 'redux'
+import { reducerName } from '../../src/names'
+import { sendPageView, SEND_PAGE_VIEW, replaceLocation } from '../../src/actions'
+import reducer from '../../src/reducer'
+import analyticsMiddleware from '../../src/analyticsMiddleware'
+import { top, news } from '../_data/location'
+import { mockState1 } from '../_data/state'
+import { mapStateToVariables } from '../_data/mapFunction'
+import { pageViewMixins } from '../_data/mixins'
+import { withPageViewPayload } from '../_data/middlewareOutput'
+import { pageViewVariables } from '../_data/variables'
+
+describe('suppress page view', () => {
+  let store
+  let testApply
+  beforeEach(() => {
+    const analytics = analyticsMiddleware({
+      pageViewMixins,
+      mapStateToVariables,
+      suppressPageView: (state, action) => {
+        const lastPageView = state[reducerName].page.lastPageViewSent
+        return lastPageView && lastPageView.location.pathname === action.payload.location.pathname
+      },
+    })
+    store = createStore(combineReducers({
+      [reducerName]: reducer,
+      article: (state) => ({ ...state }),
+      routing: (state) => ({ ...state }),
+    }), mockState1, applyMiddleware(analytics))
+    testApply = analytics(store)((action) => action)
+  })
+
+  it('dispatched at the first PageView', () => {
+    store.dispatch(replaceLocation(top, true))
+    const action = testApply(sendPageView(pageViewVariables, false))
+    expect(action).to.deep.equal({
+      type: SEND_PAGE_VIEW,
+      payload: {
+        location: top,
+        variables: withPageViewPayload['*,false,*'],
+        update: {
+          location: null,
+          variables: pageViewVariables,
+        },
+      },
+    })
+  })
+
+  it('suppress if location does not change', () => {
+    store.dispatch(replaceLocation(top, true))
+    const action = sendPageView(pageViewVariables, false)
+    store.dispatch(action)
+    const action2 = testApply(sendPageView(pageViewVariables, false))
+    expect(action2).to.equal(null)
+    const action3 = testApply(sendPageView(pageViewVariables, false))
+    expect(action3).to.equal(null)
+  })
+
+  it('dispatched if location changes', () => {
+    store.dispatch(replaceLocation(top, true))
+    const action = sendPageView(pageViewVariables, false)
+    store.dispatch(action)
+    store.dispatch(replaceLocation(top, true))
+    const action2 = testApply(sendPageView(pageViewVariables, false))
+    expect(action2).to.deep.equal({
+      type: SEND_PAGE_VIEW,
+      payload: {
+        location: top,
+        variables: withPageViewPayload['*,false,*'],
+        update: {
+          location: null,
+          variables: pageViewVariables,
+        },
+      },
+    })
+    store.dispatch(action2)
+    const action3 = testApply(sendPageView(pageViewVariables, false))
+    expect(action3).to.equal(null)
+  })
+
+  it('dispatched if different location is specified in payload', () => {
+    store.dispatch(replaceLocation(top, true))
+    const action = sendPageView(pageViewVariables, false)
+    store.dispatch(action)
+    const action2 = testApply(sendPageView(pageViewVariables, false, news))
+    expect(action2).to.deep.equal({
+      type: SEND_PAGE_VIEW,
+      payload: {
+        location: news,
+        variables: withPageViewPayload['*,false,*'],
+        update: {
+          location: news,
+          variables: pageViewVariables,
+        },
+      },
+    })
+    store.dispatch(action2)
+    const action3 = testApply(sendPageView(pageViewVariables, false))
+    expect(action3).to.equal(null)
+  })
+})


### PR DESCRIPTION
 Add new option ```suppressPageView()``` to analyticsMiddleware.
This callback is evaluated just before the middleware passes transformed PageView action to next middleware, and if the result is true, the middleware discards the action before it reaches to the next middleware.
